### PR TITLE
Update useMachine.ts

### DIFF
--- a/src/useMachine.ts
+++ b/src/useMachine.ts
@@ -29,7 +29,7 @@ export function useMachine<
 } {
 	const service = useInterpret(getMachine, options, listener);
 
-	const { initialState } = service.machine;
+	const { initialState } = service;
 	const state = shallowRef(
 		(options.state ? State.create(options.state) : initialState) as State<
 			TContext,


### PR DESCRIPTION
We attempt to use `useMachine` with `Actor model` in vue, but I noticed the `entry` with print two times. After debug, `useInterpret` will print one time, and `service.machine. initialState` will print another time.  In the [source code](https://github.com/statelyai/xstate/blob/68692c1d11df7a513e68d4ce888603c1ffe41552/packages/core/src/interpreter.ts#L1339) `spawn` depend on a `service`, but execute `service.machine. initialState` directly, `service` will be `undefined` now. 
[`service.machine`](https://github.com/statelyai/xstate/blob/68692c1d11df7a513e68d4ce888603c1ffe41552/packages/core/src/interpreter.ts#L218) will provide `this` first, `this.machine.initialState` will get the correct `service`.

```javascript
const { Machine, interpret, assign, createMachine, sendParent, send, spawn } = require('xstate');
const remoteMachine = createMachine({
  id: 'remote',
  initial: 'offline',
  states: {
    offline: {
      on: {
        WAKE: 'online'
      }
    },
    online: {
      after: {
        1000: {
          actions: sendParent('REMOTE.ONLINE')
        }
      }
    }
  }
});

const parentMachine = createMachine({
  id: 'parent',
  initial: 'waiting',
  context: {
    localOne: null
  },
  states: {
    waiting: {
      entry: assign({
        localOne: () => {
          console.log('entry');
          return spawn(remoteMachine);
        }
      }),
      on: {
        'LOCAL.WAKE': {
          actions: send({ type: 'WAKE' }, { to: (context) => context.localOne })
        },
        'REMOTE.ONLINE': { target: 'connected' }
      }
    },
    connected: {}
  }
});
const parentService = interpret(parentMachine)
  .onTransition((state) => console.log(state.value))
  .start();

console.log(parentService.initialState.context);  // print entry once, context.localOne is Interpreter(Actor)
console.log(parentService.machine.initialState.context); // print entry twice, context.localOne  will be nullActor(https://github.com/statelyai/xstate/blob/68692c1d11df7a513e68d4ce888603c1ffe41552/packages/core/src/Actor.ts#L29) 
```